### PR TITLE
LPS-86490 Avoid remaining notification-container element makes non-clickable elements in UI

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
@@ -16,11 +16,13 @@
 	overflow: auto;
 	padding-left: 15px;
 	padding-right: 15px;
+	padding-top: 15px;
 	position: fixed;
 	width: 100%;
 	z-index: 5000;
 
 	.lfr-notification-wrapper {
+		margin-bottom: 5px;
 		overflow: hidden;
 		overflow-wrap: break-word;
 		word-wrap: break-word;

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
@@ -16,13 +16,11 @@
 	overflow: auto;
 	padding-left: 15px;
 	padding-right: 15px;
-	padding-top: 15px;
 	position: fixed;
 	width: 100%;
 	z-index: 5000;
 
 	.lfr-notification-wrapper {
-		margin-bottom: 5px;
 		overflow: hidden;
 		overflow-wrap: break-word;
 		word-wrap: break-word;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -539,6 +539,18 @@ AUI.add(
 						);
 					},
 
+					_destroyBanner: function() {
+						var instance = this;
+
+						instance._banner = false;
+
+						var notificationContainer = A.one('.lfr-notification-container');
+
+						if (notificationContainer) {
+							notificationContainer.remove();
+						}
+					},
+
 					_formatNumber: function(value) {
 						var instance = this;
 
@@ -593,6 +605,10 @@ AUI.add(
 												event.domEvent.preventDefault();
 												instance._host.extend();
 											}
+											else if (event.domEvent.target.test('.close')){
+												instance._destroyBanner();
+												instance._alertClosed = true;
+											}
 										}
 									},
 									title: Liferay.Language.get('warning'),
@@ -624,7 +640,7 @@ AUI.add(
 						var banner = instance._getBanner();
 
 						if (banner) {
-							banner.hide();
+							instance._destroyBanner();
 						}
 					},
 
@@ -644,22 +660,24 @@ AUI.add(
 						DOC.title = instance.get('pageTitle');
 					},
 
-					_uiSetRemainingTime: function(remainingTime, counterTextNode) {
+					_uiSetRemainingTime: function(remainingTime) {
 						var instance = this;
-
-						var banner = instance._getBanner();
 
 						remainingTime = instance._formatTime(remainingTime);
 
-						banner.set(
-							'message',
-							Lang.sub(
-								instance._warningText,
-								[
-									remainingTime
-								]
-							)
-						);
+						if (!instance._alertClosed){
+							var banner = instance._getBanner();
+
+							banner.set(
+								'message',
+								Lang.sub(
+									instance._warningText,
+									[
+										remainingTime
+									]
+								)
+							);
+						}
 
 						DOC.title = Lang.sub(Liferay.Language.get('session-expires-in-x'), [remainingTime]) + ' | ' + instance.get('pageTitle');
 					}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -605,7 +605,7 @@ AUI.add(
 												event.domEvent.preventDefault();
 												instance._host.extend();
 											}
-											else if (event.domEvent.target.test('.close')){
+											else if (event.domEvent.target.test('.close')) {
 												instance._destroyBanner();
 												instance._alertClosed = true;
 											}
@@ -665,7 +665,7 @@ AUI.add(
 
 						remainingTime = instance._formatTime(remainingTime);
 
-						if (!instance._alertClosed){
+						if (!instance._alertClosed) {
 							var banner = instance._getBanner();
 
 							banner.set(


### PR DESCRIPTION
Hi Julien,

Can you review this PR, please?

In [LPS-86490](https://issues.liferay.com/browse/LPS-86490) you can find more information about what is the issue and how to reproduce it.

We have two approaches to solve it:

1. Keep hiding the notification container but make it zero height hence is not blocking any element in the DOM. You can find the reasons for this approach [here](https://issues.liferay.com/browse/LPS-86490?focusedCommentId=1604359&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1604359).
2. Remove the whole notification container from the DOM once the pop-up is closed (because we extended the session or close it clicking on 'X' button). You can find the reasons for this approach [here](https://issues.liferay.com/browse/LPS-84988?focusedCommentId=1606439&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1606439).

If you, as Product Team, decide to pick first option, just get rid of my two commits.

In case you need any help, don't hesitate to ask me.

Thanks,

//cc @NemethNorbert