### PR TITLE
LPS-94708 | Deprecate History utilities

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/upload.js
@@ -3,7 +3,6 @@ AUI.add(
 	function(A) {
 		var AArray = A.Array;
 		var ANode = A.Node;
-		var HistoryManager = Liferay.HistoryManager;
 		var Lang = A.Lang;
 		var LString = Lang.String;
 		var UploaderQueue = A.Uploader.Queue;
@@ -791,9 +790,7 @@ AUI.add(
 					_getDisplayStyle: function(style) {
 						var instance = this;
 
-						var displayStyleNamespace = instance.get(STR_HOST).ns('displayStyle');
-
-						var displayStyle = HistoryManager.get(displayStyleNamespace) || instance._displayStyle;
+						var displayStyle = instance._displayStyle;
 
 						if (style) {
 							displayStyle = style == displayStyle;
@@ -1397,6 +1394,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['aui-component', 'aui-data-set-deprecated', 'aui-overlay-manager-deprecated', 'aui-overlay-mask-deprecated', 'aui-parse-content', 'aui-progressbar', 'aui-template-deprecated', 'aui-tooltip', 'liferay-history-manager', 'liferay-search-container', 'liferay-storage-formatter', 'querystring-parse-simple', 'uploader']
+		requires: ['aui-component', 'aui-data-set-deprecated', 'aui-overlay-manager-deprecated', 'aui-overlay-mask-deprecated', 'aui-parse-content', 'aui-progressbar', 'aui-template-deprecated', 'aui-tooltip', 'liferay-search-container', 'liferay-storage-formatter', 'querystring-parse-simple', 'uploader']
 	}
 );

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/history.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/history.js
@@ -1,3 +1,10 @@
+/**
+ * The History Utility, a utility for SPA.
+ *
+ * @deprecated since 7.2, unused, replaced by senna.js
+ * @module liferay-history
+ */
+
 AUI.add(
 	'liferay-history',
 	function(A) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/history_manager.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/history_manager.js
@@ -1,3 +1,10 @@
+/**
+ * The History Manager, a utility for SPA.
+ *
+ * @deprecated since 7.2, unused, replaced by senna.js
+ * @module liferay-history-manager
+ */
+
 AUI.add(
 	'liferay-history-manager',
 	function(A) {


### PR DESCRIPTION
Hi @julien ,

These utilities are for SPA implementation based on YUI History Utility. We have not been using this for a long time. The code in document library checks for a global object that will never have any properties set.

Please review the code.

Thank you!