### PR TITLE
LPS-98280 | Apply new Portlet URL utilities in calendar-web

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_util.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_util.js
@@ -275,8 +275,7 @@ AUI.add(
 			'aui-scheduler',
 			'aui-toolbar',
 			'autocomplete',
-			'autocomplete-highlighters',
-			'liferay-portlet-url'
+			'autocomplete-highlighters'
 		]
 	}
 );

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
@@ -81,8 +81,7 @@
 							'aui-base',
 							'aui-component',
 							'liferay-calendar-util',
-							'liferay-portlet-base',
-							'liferay-portlet-url'
+							'liferay-portlet-base'
 						]
 					},
 					'liferay-calendar-session-listener': {

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
@@ -540,8 +540,7 @@ AUI.add(
 			'aui-component',
 			'liferay-calendar-message-util',
 			'liferay-calendar-util',
-			'liferay-portlet-base',
-			'liferay-portlet-url'
+			'liferay-portlet-base'
 		]
 	}
 );

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
@@ -29,21 +29,27 @@ AUI.add(
 			A.Base,
 			[Liferay.PortletBase],
 			{
-				_invokeActionURL(params) {
+				_invokeActionURL(config) {
 					var instance = this;
 
-					var url = Liferay.PortletURL.createActionURL();
+					var actionParameters = {
+						'javax.portlet.action': config.actionName,
+						p_p_id: instance.ID
+					};
 
-					url.setName(params.actionName);
-					url.setParameters(params.queryParameters);
-					url.setPortletId(instance.ID);
+					A.mix(actionParameters, config.queryParameters);
+
+					var url = Liferay.Util.PortletURL.createActionURL(
+						Liferay.ThemeDisplay.getPortalURL(),
+						actionParameters
+					);
 
 					var payload;
 
-					if (params.payload) {
+					if (config.payload) {
 						payload = Liferay.Util.ns(
 							instance.get('namespace'),
-							params.payload
+							config.payload
 						);
 					}
 
@@ -61,28 +67,32 @@ AUI.add(
 							return response.json();
 						})
 						.then(data => {
-							params.callback(data);
+							config.callback(data);
 						});
 				},
 
-				_invokeResourceURL(params) {
+				_invokeResourceURL(config) {
 					var instance = this;
 
-					var url = Liferay.PortletURL.createResourceURL();
+					var resourceParameters = {
+						doAsUserId: Liferay.ThemeDisplay.getDoAsUserIdEncoded(),
+						p_p_id: instance.ID,
+						p_p_resource_id: config.resourceId
+					};
 
-					url.setDoAsUserId(
-						Liferay.ThemeDisplay.getDoAsUserIdEncoded()
+					A.mix(resourceParameters, config.queryParameters);
+
+					var url = Liferay.Util.PortletURL.createResourceURL(
+						Liferay.ThemeDisplay.getPortalURL(),
+						resourceParameters
 					);
-					url.setParameters(params.queryParameters);
-					url.setPortletId(instance.ID);
-					url.setResourceId(params.resourceId);
 
 					var payload;
 
-					if (params.payload) {
+					if (config.payload) {
 						payload = Liferay.Util.ns(
 							instance.get('namespace'),
-							params.payload
+							config.payload
 						);
 					}
 
@@ -103,7 +113,7 @@ AUI.add(
 						})
 						.then(data => {
 							if (data.length) {
-								params.callback(JSON.parse(data));
+								config.callback(JSON.parse(data));
 							}
 						});
 				},

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
@@ -12,6 +12,13 @@
  * details.
  */
 
+/**
+ * The Portlet URL Utility
+ *
+ * @deprecated since 7.3, replaced by Liferay.Util.PortletURL
+ * @module liferay-portlet-url
+ */
+
 AUI.add(
 	'liferay-portlet-url',
 	function(A) {


### PR DESCRIPTION
Hey @julien ,

@kresimir-coko previously made these changes and they somehow ended up in  https://github.com/inacionery/liferay-portal/pull/212. Commits and their ownership in that PR are a bit weird :) Anyways, there were issues with CI, and you resent other changes in https://github.com/inacionery/liferay-portal/pull/215. But, you did not forward these.

In this PR I am resending Krešo's commits; I fixed conflicts with recent changes and removed usages of `Object.assign`, as this is AUI module. I marked the old util as deprecated. I am not sure if there is any other reason why you didn't forward it.

If all is ok, please forward to @inacionery

Thank you!

/cc @jbalsas