### PR TITLE
LPS-106715 Language selector should show editable/translated number

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Translation.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Translation.js
@@ -111,8 +111,10 @@ const TranslationItem = ({
 				>
 					{TRANSLATION_STATUS_LANGUAGE[status]}
 					{TRANSLATION_STATUS_TYPE[status] ===
-						TRANSLATION_STATUS_TYPE.translating &&
-						`${translatedValuesLength}/${editableValuesLength}`}
+						(TRANSLATION_STATUS_TYPE.untranslated ||
+							TRANSLATION_STATUS_TYPE.translating ||
+							TRANSLATION_STATUS_TYPE.translated) &&
+						` ${translatedValuesLength}/${editableValuesLength}`}
 				</div>
 			</span>
 		</ClayDropDown.Item>


### PR DESCRIPTION
Hi @julien. 

The conditioning logic for translating status already exists in the code on lines from 57 to 80 https://github.com/liferay/liferay-portal/blob/d8a2ce9cd4b2c183490f9d281d6cda7185b71bc9/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Translation.js#L57  in `Translation.js` . 
I wasn't sure what correctly is required for this task, since there is a task https://issues.liferay.com/browse/LPS-107179 which is related to translating functionality of the editable content when changing the language. I believe it was only needed to add `editable number/translated number` to translation statuses which are not default.  