### PR TITLE
LPS-108631 Sidebar fragments show unneeded tooltip

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/FragmentCard.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/FragmentCard.js
@@ -101,9 +101,7 @@ export default function FragmentCard({
 			<div className="card-body">
 				<div className="card-row">
 					<div className="autofit-col autofit-col-expand autofit-row-center">
-						<div className="card-title text-truncate" title={name}>
-							{name}
-						</div>
+						<div className="card-title text-truncate">{name}</div>
 					</div>
 				</div>
 			</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/LayoutElements.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/LayoutElements.js
@@ -101,9 +101,7 @@ const LayoutElementCard = ({label, layoutColumns, type}) => {
 						))}
 					</div>
 				</div>
-				<div className="card-title pt-3 text-truncate" title={label}>
-					{label}
-				</div>
+				<div className="card-title pt-3 text-truncate">{label}</div>
 			</div>
 		</button>
 	);


### PR DESCRIPTION
Remove `title` attribute, fragment  cards already have a descriptive text.
Tooltips invoke and track any component with the title attribute and add the tooltip.