### PR TITLE
LPS-111241 Replace <liferay-ui:input-editor> with liferay-editor:editor in frontend-taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/email_notification_settings/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/email_notification_settings/page.jsp
@@ -67,7 +67,7 @@ boolean showSubject = GetterUtil.getBoolean(request.getAttribute("liferay-fronte
 				/>
 			</c:when>
 			<c:otherwise>
-				<liferay-ui:input-editor
+				<liferay-editor:editor
 					contents="<%= emailBody %>"
 					editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.email_notification_settings.jsp") %>'
 					name="<%= emailParam %>"

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -20,6 +20,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@


### PR DESCRIPTION
The goal of this change is to replace <liferay-ui:input-editor>
(which was deprecated in 7.1.0) with <liferay-editor:editor>.