### PR TITLE
LPS-111237 Replace <liferay-ui:input-editor> with <liferay-editor:editor> in comment-web

### DIFF
--- a/modules/apps/comment/comment-web/build.gradle
+++ b/modules/apps/comment/comment-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:comment:comment-api")
+	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/edit_discussion.jsp
+++ b/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/edit_discussion.jsp
@@ -80,7 +80,7 @@ if (comment instanceof WorkflowableComment) {
 				<aui:workflow-status model="<%= CommentConstants.getDiscussionClass() %>" status="<%= workflowableComment.getStatus() %>" />
 			</c:if>
 
-			<liferay-ui:input-editor
+			<liferay-editor:editor
 				configKey="commentEditor"
 				contents="<%= comment.getBody() %>"
 				editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.discussion.jsp") %>'

--- a/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@


### PR DESCRIPTION
The goal of this change is to replace liferay-ui:input-editor
(which was deprecated in 7.1.0) with liferay-editor:editor.