### PR TITLE
LPS-111234 Replace <liferay-ui:input-editor> with <liferay-editor:editor> in comment-taglib

### DIFF
--- a/modules/apps/comment/comment-taglib/build.gradle
+++ b/modules/apps/comment/comment-taglib/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:comment:comment-api")
+	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:message-boards:message-boards-api")

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/editor_resource.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/editor_resource.jsp
@@ -23,7 +23,7 @@ String onChangeMethod = GetterUtil.getString(request.getAttribute("liferay-comme
 String placeholder = GetterUtil.getString(request.getAttribute("liferay-comment:editor:placeholder"));
 %>
 
-<liferay-ui:input-editor
+<liferay-editor:editor
 	autoCreate="<%= true %>"
 	configKey="commentEditor"
 	contents="<%= contents %>"

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -128,7 +128,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 											</div>
 
 											<div class="autofit-col autofit-col-expand lfr-discussion-editor">
-												<liferay-ui:input-editor
+												<liferay-editor:editor
 													configKey="commentEditor"
 													contents=""
 													editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.discussion.jsp") %>'

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -20,6 +20,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>


### PR DESCRIPTION
The goal of this change is to replace <liferay-ui:input-editor>
(which was deprecated in 7.1.0) with <liferay-editor:editor>.