### PR TITLE
LPS-110011

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -53,7 +53,7 @@ String editorName = (String)request.getAttribute(AlloyEditorConstants.ATTRIBUTE_
 				alloyEditorInstances = 0;
 				alloyEditorDisposeResources = false;
 
-				if (Object.keys(CKEDITOR.instances).length === 0) {
+				if (CKEDITOR && Object.keys(CKEDITOR.instances).length === 0) {
 					window.CKEDITOR = undefined;
 				}
 			}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -670,9 +670,11 @@ AUI.add(
 		Liferay.on('destroyPortlet', event => {
 			var portletNamespace = '_' + event.portletId + '_';
 
-			A.Object.each(Liferay.InputLocalized._instances, item => {
+			A.Object.each(Liferay.InputLocalized._instances, (item, id) => {
 				if (item.get('namespace') === portletNamespace) {
 					item.destroy();
+
+					Liferay.destroyComponent(id);
 				}
 			});
 		});

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -657,7 +657,13 @@ AUI.add(
 					instances[id] = inputLocalizedInstance;
 				}
 
-				Liferay.component(id, inputLocalizedInstance);
+				var portletId = inputLocalizedInstance
+					.get('namespace')
+					.replace(/^_|_$/gm, '');
+
+				Liferay.component(id, inputLocalizedInstance, {
+					portletId,
+				});
 			},
 
 			unregister(id) {
@@ -666,18 +672,6 @@ AUI.add(
 		});
 
 		Liferay.InputLocalized = InputLocalized;
-
-		Liferay.on('destroyPortlet', event => {
-			var portletNamespace = '_' + event.portletId + '_';
-
-			A.Object.each(Liferay.InputLocalized._instances, (item, id) => {
-				if (item.get('namespace') === portletNamespace) {
-					item.destroy();
-
-					Liferay.destroyComponent(id);
-				}
-			});
-		});
 	},
 	'',
 	{

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionEditorConfigContributor.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionEditorConfigContributor.java
@@ -50,6 +50,8 @@ public class JournalArticleDescriptionEditorConfigContributor
 		jsonObject.put(
 			"allowedContent", "p br strong i ol ul li u link pre em a"
 		).put(
+			"height", "120"
+		).put(
 			"toolbars", getToolbarsJSONObject(themeDisplay.getLocale())
 		);
 	}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -95,7 +95,6 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 		formName="fm"
 		ignoreRequestValue="<%= journalEditArticleDisplayContext.isChangeStructure() %>"
 		name="descriptionMapAsXML"
-		placeholder="description"
 		selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>"
 		type="editor"
 		xml="<%= (article != null) ? article.getDescriptionMapAsXML() : StringPool.BLANK %>"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -84,14 +84,14 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 	</c:otherwise>
 </c:choose>
 
-<div class="article-content-description">
+<div>
 	<label for="<portlet:namespace />descriptionMapAsXML"><liferay-ui:message key="summary" /></label>
 
 	<liferay-ui:input-localized
 		availableLocales="<%= journalEditArticleDisplayContext.getAvailableLocales() %>"
 		cssClass="form-control"
 		defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"
-		editorName="alloyeditor"
+		editorName="ckeditor"
 		formName="fm"
 		ignoreRequestValue="<%= journalEditArticleDisplayContext.isChangeStructure() %>"
 		name="descriptionMapAsXML"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -292,7 +292,12 @@ class JournalPortlet extends PortletBase {
 				inputComponent.selectFlag(selectedLanguageId);
 				inputComponent.updateInput(inputDefaultValue);
 
-				eventHandler.detach();
+				// setInterval declared in ckeditor.jsp is triggering
+				// the updateInputLanguage function, so with this
+				// we guarantee that this function is not called
+				setTimeout(() => {
+					eventHandler.detach();
+				}, 400);
 			}
 		}
 	}


### PR DESCRIPTION
Hey Julien!

I've noticed that input_localized components were not destroying when navigating on SPA, It showed the warning that the componente was defined twice. In the past it wasn't harmful but with the move to ckeditor things started to break after navigate. This is solved in this commit 456d9bf, another posible solution will be to extract the portletId from the namespace (basically the namespace is created as `_${portletId}_`) and pass it to the Liferay.component call like `Liferay.component(id, inputLocalizedInstance, {portletId})`.

@jbalsas