### PR TITLE
LPS-101618 Deprecate `Liferay.Util.toggleDisabled`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -963,32 +963,6 @@
 			}
 		},
 
-		toggleDisabled(nodes, state) {
-			if (typeof nodes === 'string') {
-				nodes = document.querySelectorAll(nodes);
-			}
-			else if (nodes._node) {
-				nodes = [nodes.getDOM()];
-			}
-			else if (nodes._nodes) {
-				nodes = nodes.getDOM();
-			}
-			else if (nodes.nodeType === 1) {
-				nodes = [nodes];
-			}
-
-			nodes.forEach((node) => {
-				node.disabled = state;
-
-				if (state) {
-					node.classList.add('disabled');
-				}
-				else {
-					node.classList.remove('disabled');
-				}
-			});
-		},
-
 		toggleRadio(radioId, showBoxIds, hideBoxIds) {
 			const radioButton = document.getElementById(radioId);
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -79,3 +79,4 @@ export {default as isPhone} from './liferay/util/is_phone';
 export {default as isTablet} from './liferay/util/is_tablet';
 export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
+export {default as toggleDisabled} from './liferay/util/toggle_disabled';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
@@ -15,7 +15,7 @@
 import Component from 'metal-component';
 import {Config} from 'metal-state';
 
-import {toggleDisabled} from './util/toggle_disabled';
+import toggleDisabled from './util/toggle_disabled';
 
 /**
  * Shows a dialog and handles the selected item.

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
@@ -15,6 +15,8 @@
 import Component from 'metal-component';
 import {Config} from 'metal-state';
 
+import {toggleDisabled} from './util/toggle_disabled';
+
 /**
  * Shows a dialog and handles the selected item.
  */
@@ -132,7 +134,7 @@ class ItemSelectorDialog extends Component {
 				.get('boundingBox')
 				.one('#addButton');
 
-			Liferay.Util.toggleDisabled(addButton, !currentItem);
+			toggleDisabled(addButton, !currentItem);
 		}
 
 		this._currentItem = currentItem;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -68,6 +68,7 @@ import createRenderURL from './util/portlet_url/create_render_url.es';
 import createResourceURL from './util/portlet_url/create_resource_url.es';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import toCharCode from './util/to_char_code.es';
+import toggleDisabled from './util/toggle_disabled';
 
 Liferay = window.Liferay || {};
 
@@ -198,6 +199,11 @@ Liferay.Util.PortletURL = {
 Liferay.Util.postForm = postForm;
 Liferay.Util.setFormValues = setFormValues;
 Liferay.Util.toCharCode = toCharCode;
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {toggleDisabled} from 'frontend-js-web'`
+ */
+Liferay.Util.toggleDisabled = toggleDisabled;
 
 Liferay.Util.openModal = (...args) => {
 	Liferay.Loader.require(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
@@ -32,10 +32,6 @@ export default function toggleDisabled(nodes, state) {
 	}
 
 	nodes.forEach((node) => {
-		if (typeof state !== 'boolean') {
-			return;
-		}
-
 		node.disabled = state;
 
 		if (state) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
@@ -30,8 +30,14 @@ export default function toggleDisabled(nodes, state) {
 	else if (nodes.nodeType === 1) {
 		nodes = [nodes];
 	}
+
 	nodes.forEach((node) => {
+		if (typeof state !== 'boolean') {
+			return;
+		}
+
 		node.disabled = state;
+
 		if (state) {
 			node.classList.add('disabled');
 		}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/**
+ * Toggles disabled class on received element
+ * @param nodes
+ * @param state
+ */
+export default function toggleDisabled(nodes, state) {
+	if (typeof nodes === 'string') {
+		nodes = document.querySelectorAll(nodes);
+	}
+	else if (nodes._node) {
+		nodes = [nodes._node];
+	}
+	else if (nodes._nodes) {
+		nodes = nodes._nodes;
+	}
+	else if (nodes.nodeType === 1) {
+		nodes = [nodes];
+	}
+	nodes.forEach((node) => {
+		node.disabled = state;
+		if (state) {
+			node.classList.add('disabled');
+		}
+		else {
+			node.classList.remove('disabled');
+		}
+	});
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js
@@ -27,7 +27,7 @@ export default function toggleDisabled(nodes, state) {
 	else if (nodes._nodes) {
 		nodes = nodes._nodes;
 	}
-	else if (nodes.nodeType === 1) {
+	else if (nodes.nodeType === Node.ELEMENT_NODE) {
 		nodes = [nodes];
 	}
 

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
@@ -17,17 +17,20 @@ import toggleDisabled from '../../../src/main/resources/META-INF/resources/lifer
 describe('Liferay.Uitl.toggleDisabled', () => {
 	beforeEach(() => {
 		const fragment = document.createDocumentFragment();
+
 		for (let i = 0; i < 10; i++) {
 			const button = document.createElement('button');
 			button.setAttribute('id', `button-${i + 1}`);
 			button.classList.add('test-button');
 			fragment.appendChild(button);
 		}
+
 		document.body.appendChild(fragment);
 	});
 
 	afterEach(() => {
 		const buttons = document.querySelectorAll('button.test-button');
+
 		if (buttons) {
 			buttons.forEach((button) => {
 				document.body.removeChild(button);
@@ -39,6 +42,7 @@ describe('Liferay.Uitl.toggleDisabled', () => {
 		toggleDisabled('button.test-button', 'disabled');
 
 		const nodes = document.querySelectorAll('button.test-button');
+
 		nodes.forEach((node) => {
 			expect(node.disabled).toEqual(true);
 		});

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
@@ -35,17 +35,8 @@ describe('Liferay.Uitl.toggleDisabled', () => {
 		}
 	});
 
-	it("doesn't set the `disabled` attribute on a collection of nodes if the `state` argument is not a boolean", () => {
+	it('sets the `disabled` attribute on a collection of nodes if the `state` argument is passed', () => {
 		toggleDisabled('button.test-button', 'disabled');
-
-		const nodes = document.querySelectorAll('button.test-button');
-		nodes.forEach((node) => {
-			expect(node.disabled).toEqual(false);
-		});
-	});
-
-	it('sets the `disabled` attribute on a collection of nodes if the `state` argument is a boolean', () => {
-		toggleDisabled('button.test-button', true);
 
 		const nodes = document.querySelectorAll('button.test-button');
 		nodes.forEach((node) => {

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
@@ -35,8 +35,18 @@ describe('Liferay.Uitl.toggleDisabled', () => {
 		}
 	});
 
-	it('sets the `disabled` attribute on a collection nodes according to the `state` argument', () => {
+	it("doesn't set the `disabled` attribute on a collection of nodes if the `state` argument is not a boolean", () => {
 		toggleDisabled('button.test-button', 'disabled');
+
+		const nodes = document.querySelectorAll('button.test-button');
+		nodes.forEach((node) => {
+			expect(node.disabled).toEqual(false);
+		});
+	});
+
+	it('sets the `disabled` attribute on a collection of nodes if the `state` argument is a boolean', () => {
+		toggleDisabled('button.test-button', true);
+
 		const nodes = document.querySelectorAll('button.test-button');
 		nodes.forEach((node) => {
 			expect(node.disabled).toEqual(true);

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_disabled.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import toggleDisabled from '../../../src/main/resources/META-INF/resources/liferay/util/toggle_disabled';
+
+describe('Liferay.Uitl.toggleDisabled', () => {
+	beforeEach(() => {
+		const fragment = document.createDocumentFragment();
+		for (let i = 0; i < 10; i++) {
+			const button = document.createElement('button');
+			button.setAttribute('id', `button-${i + 1}`);
+			button.classList.add('test-button');
+			fragment.appendChild(button);
+		}
+		document.body.appendChild(fragment);
+	});
+
+	afterEach(() => {
+		const buttons = document.querySelectorAll('button.test-button');
+		if (buttons) {
+			buttons.forEach((button) => {
+				document.body.removeChild(button);
+			});
+		}
+	});
+
+	it('sets the `disabled` attribute on a collection nodes according to the `state` argument', () => {
+		toggleDisabled('button.test-button', 'disabled');
+		const nodes = document.querySelectorAll('button.test-button');
+		nodes.forEach((node) => {
+			expect(node.disabled).toEqual(true);
+		});
+	});
+});

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {ItemSelectorDialog, toggleDisabled} from 'frontend-js-web';
 
 import {previewSeoFireChange} from './PreviewSeoEvents.es';
 
@@ -55,12 +55,9 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 			openGraphImageFileEntryId.value = itemValue.fileEntryId;
 			openGraphImageTitle.value = itemValue.title;
 
-			Liferay.Util.toggleDisabled(openGraphImageAltField, false);
-			Liferay.Util.toggleDisabled(
-				openGraphImageAltFieldDefaultLocale,
-				false
-			);
-			Liferay.Util.toggleDisabled(openGraphImageAltLabel, false);
+			toggleDisabled(openGraphImageAltField, false);
+			toggleDisabled(openGraphImageAltFieldDefaultLocale, false);
+			toggleDisabled(openGraphImageAltLabel, false);
 
 			previewSeoFireChange(namespace, {
 				type: 'imgUrl',
@@ -81,9 +78,9 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 		openGraphImageFileEntryId.value = '';
 		openGraphImageTitle.value = '';
 
-		Liferay.Util.toggleDisabled(openGraphImageAltField, true);
-		Liferay.Util.toggleDisabled(openGraphImageAltFieldDefaultLocale, true);
-		Liferay.Util.toggleDisabled(openGraphImageAltLabel, true);
+		toggleDisabled(openGraphImageAltField, true);
+		toggleDisabled(openGraphImageAltFieldDefaultLocale, true);
+		toggleDisabled(openGraphImageAltLabel, true);
 
 		previewSeoFireChange(namespace, {
 			type: 'imgUrl',
@@ -104,8 +101,8 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 	openGraphTitleEnabledCheck.addEventListener('click', (event) => {
 		const disabled = !event.target.checked;
 
-		Liferay.Util.toggleDisabled(openGraphTitleField, disabled);
-		Liferay.Util.toggleDisabled(openGraphTitleFieldDefaultLocale, disabled);
+		toggleDisabled(openGraphTitleField, disabled);
+		toggleDisabled(openGraphTitleFieldDefaultLocale, disabled);
 
 		previewSeoFireChange(namespace, {
 			disabled,
@@ -127,11 +124,8 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 	openGraphDescriptionEnabledCheck.addEventListener('click', (event) => {
 		const disabled = !event.target.checked;
 
-		Liferay.Util.toggleDisabled(openGraphDescriptionField, disabled);
-		Liferay.Util.toggleDisabled(
-			openGraphDescriptionFieldDefaultLocale,
-			disabled
-		);
+		toggleDisabled(openGraphDescriptionField, disabled);
+		toggleDisabled(openGraphDescriptionFieldDefaultLocale, disabled);
 
 		previewSeoFireChange(namespace, {
 			disabled,

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {ItemSelectorDialog} from 'frontend-js-web';
+import {ItemSelectorDialog, toggleDisabled} from 'frontend-js-web';
 
 export default function ({namespace, uploadOpenGraphImageURL}) {
 	const openGraphImageButton = document.getElementById(
@@ -57,12 +57,9 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 			openGraphImageTitle.value = itemValue.title;
 			openGraphPreviewImage.src = itemValue.url;
 
-			Liferay.Util.toggleDisabled(openGraphImageAltField, false);
-			Liferay.Util.toggleDisabled(
-				openGraphImageAltFieldDefaultLocale,
-				false
-			);
-			Liferay.Util.toggleDisabled(openGraphImageAltLabel, false);
+			toggleDisabled(openGraphImageAltField, false);
+			toggleDisabled(openGraphImageAltFieldDefaultLocale, false);
+			toggleDisabled(openGraphImageAltLabel, false);
 
 			openGraphPreviewImage.classList.remove('hide');
 		}
@@ -82,9 +79,9 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 		openGraphImageTitle.value = '';
 		openGraphPreviewImage.src = '';
 
-		Liferay.Util.toggleDisabled(openGraphImageAltField, true);
-		Liferay.Util.toggleDisabled(openGraphImageAltFieldDefaultLocale, true);
-		Liferay.Util.toggleDisabled(openGraphImageAltLabel, true);
+		toggleDisabled(openGraphImageAltField, true);
+		toggleDisabled(openGraphImageAltFieldDefaultLocale, true);
+		toggleDisabled(openGraphImageAltLabel, true);
 
 		openGraphPreviewImage.classList.add('hide');
 	});
@@ -101,22 +98,16 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 		const openGraphImageAltDisabled =
 			disabled || !openGraphImageTitle.value;
 
-		Liferay.Util.toggleDisabled(openGraphImageTitle, disabled);
-		Liferay.Util.toggleDisabled(openGraphImageButton, disabled);
-		Liferay.Util.toggleDisabled(openGraphClearImageButton, disabled);
+		toggleDisabled(openGraphImageTitle, disabled);
+		toggleDisabled(openGraphImageButton, disabled);
+		toggleDisabled(openGraphClearImageButton, disabled);
 
-		Liferay.Util.toggleDisabled(
-			openGraphImageAltField,
-			openGraphImageAltDisabled
-		);
-		Liferay.Util.toggleDisabled(
+		toggleDisabled(openGraphImageAltField, openGraphImageAltDisabled);
+		toggleDisabled(
 			openGraphImageAltFieldDefaultLocale,
 			openGraphImageAltDisabled
 		);
-		Liferay.Util.toggleDisabled(
-			openGraphImageAltLabel,
-			openGraphImageAltDisabled
-		);
+		toggleDisabled(openGraphImageAltLabel, openGraphImageAltDisabled);
 
 		openGraphSettings.classList.toggle('disabled');
 	});

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/seo.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/seo.es.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {toggleDisabled} from 'frontend-js-web';
+
 import {previewSeoFireChange} from './PreviewSeoEvents.es';
 
 export default function ({namespace}) {
@@ -31,9 +33,9 @@ export default function ({namespace}) {
 
 		canonicalURLAlert.classList.toggle('hide');
 
-		Liferay.Util.toggleDisabled(canonicalURLField, disabled);
+		toggleDisabled(canonicalURLField, disabled);
 
-		Liferay.Util.toggleDisabled(canonicalURLFieldDefaultLocale, disabled);
+		toggleDisabled(canonicalURLFieldDefaultLocale, disabled);
 
 		previewSeoFireChange(namespace, {
 			disabled,


### PR DESCRIPTION
The goal of this change to mark the `Liferay.Util.toggleDisabled`
function as deprecated: we still need it as a global to avoid breaking
changes, but now we also provide a way to `import` the function to avoid
using globals.