### PR TITLE
LPS-101575 Deprecate unused js utilities in frontend-aui-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -920,6 +920,9 @@
 			form.submit();
 		},
 
+		/**
+		 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+		 */
 		toNumber(value) {
 			return parseInt(value, 10) || 0;
 		},


### PR DESCRIPTION
The goal of this task is to deprecate unused JS utilities in **frontend-aui-web**.
Currently the only function which needs to be deprecated is **toNumber**.