### PR TITLE
LPS-112941 Deprecate liferay-address utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/address.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/address.js
@@ -12,36 +12,9 @@
  * details.
  */
 
-AUI.add(
-	'liferay-address',
-	() => {
-		if (!Liferay.Address) {
-			Liferay.Address = {
-				getCountries(callback) {
-					Liferay.Service(
-						'/country/get-countries',
-						{
-							active: true,
-						},
-						callback
-					);
-				},
-
-				getRegions(callback, selectKey) {
-					Liferay.Service(
-						'/region/get-regions',
-						{
-							active: true,
-							countryId: Number(selectKey),
-						},
-						callback
-					);
-				},
-			};
-		}
-	},
-	'',
-	{
-		requires: [],
-	}
-);
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `Liferay.Address`
+ */
+AUI.add('liferay-address', () => {}, '', {
+	requires: [],
+});

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/address/get_countries.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/address/get_countries.es.js
@@ -12,15 +12,13 @@
  * details.
  */
 
-import {isFunction} from 'metal';
-
 /**
  * Returns a list of countries
  * @callback callback
  * @return {array} Array of countries
  */
 export default function getCountries(callback) {
-	if (!isFunction(callback)) {
+	if (typeof callback !== 'function') {
 		throw new TypeError('Parameter callback must be a function');
 	}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/address/get_regions.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/address/get_regions.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import {isFunction, isString} from 'metal';
-
 /**
  * Returns a list of regions by country
  * @callback callback
@@ -21,11 +19,11 @@ import {isFunction, isString} from 'metal';
  * @return {array} Array of regions by country
  */
 export default function getRegions(callback, selectKey) {
-	if (!isFunction(callback)) {
+	if (typeof callback !== 'function') {
 		throw new TypeError('Parameter callback must be a function');
 	}
 
-	if (!isString(selectKey)) {
+	if (typeof selectKey !== 'string') {
 		throw new TypeError('Parameter selectKey must be a string');
 	}
 

--- a/portal-web/docroot/html/taglib/ui/organization_search_form/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/organization_search_form/page.jsp
@@ -83,7 +83,7 @@ if (displayTerms.getParentOrganizationId() > 0) {
 	<liferay-ui:message key="filter-by-organization" />: <%= HtmlUtil.escape(parentOrganization.getName()) %><br />
 </c:if>
 
-<aui:script use="liferay-address,liferay-dynamic-select">
+<aui:script use="liferay-dynamic-select">
 	new Liferay.DynamicSelect(
 		[
 			{


### PR DESCRIPTION
The goal of this task is to mark **liferay-address** from AUI as deprecated — vanilla JS port to **frontend-js-web** was done in https://issues.liferay.com/browse/LPS-94694