### PR TITLE
LPS-113026 Remove `liferay-toggler-interaction` AUI component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/toggler_interaction.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/toggler_interaction.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-toggler-interaction',
 	(A) => {


### PR DESCRIPTION
The only usage of the `liferay-toggler-interaction` AUI component was
in the [`liferay-product-navigation-control-menu-add-application`](https://github.com/liferay/liferay-portal/blob/8abc9337c7f4acd55e8ef803632f26090cafe3be/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_application.js)
component - but the `togglerDelegate` variable declared
[here](https://github.com/liferay/liferay-portal/blob/8abc9337c7f4acd55e8ef803632f26090cafe3be/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_application.js#L108) is always `undefined` which means that the `Liferay.TogglerInteraction`
component is never instantiated and not needed.