### PR TITLE
LPS-114186 Migrate AUI tree-view in asset-taglib to React

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.taglib.internal.display.context;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.portlet.PortletURL;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class AssetCategoriesNavigationDisplayContext {
+
+	public AssetCategoriesNavigationDisplayContext(
+		HttpServletRequest httpServletRequest, RenderResponse renderResponse) {
+
+		_httpServletRequest = httpServletRequest;
+		_renderResponse = renderResponse;
+
+		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_vocabularyIds = (long[])httpServletRequest.getAttribute(
+			"liferay-asset:asset-tags-navigation:vocabularyIds");
+	}
+
+	public String buildVocabularyNavigation(AssetVocabulary vocabulary)
+		throws Exception {
+
+		List<AssetCategory> categories =
+			AssetCategoryServiceUtil.getVocabularyRootCategories(
+				vocabulary.getGroupId(), vocabulary.getVocabularyId(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		if (categories.isEmpty()) {
+			return null;
+		}
+
+		StringBundler sb = new StringBundler();
+
+		sb.append("<div class=\"lfr-asset-category-list-container\">");
+		sb.append("<ul class=\"lfr-asset-category-list\">");
+
+		_buildCategoriesNavigation(categories, sb);
+
+		sb.append("</ul></div>");
+
+		return sb.toString();
+	}
+
+	public long getCategoryId() {
+		if (_categoryId != null) {
+			return _categoryId;
+		}
+
+		_categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
+
+		return _categoryId;
+	}
+
+	public List<AssetVocabulary> getVocabularies() throws PortalException {
+		if (_vocabularies != null) {
+			return _vocabularies;
+		}
+
+		if (_vocabularyIds == null) {
+			_vocabularies = AssetVocabularyServiceUtil.getGroupVocabularies(
+				PortalUtil.getCurrentAndAncestorSiteGroupIds(
+					_themeDisplay.getScopeGroupId()));
+
+			return _vocabularies;
+		}
+
+		List<AssetVocabulary> vocabularies = new ArrayList<>();
+
+		for (long vocabularyId : _vocabularyIds) {
+			AssetVocabulary vocabulary =
+				AssetVocabularyServiceUtil.fetchVocabulary(vocabularyId);
+
+			if (vocabulary != null) {
+				vocabularies.add(vocabulary);
+			}
+		}
+
+		_vocabularies = vocabularies;
+
+		return _vocabularies;
+	}
+
+	private void _buildCategoriesNavigation(
+			List<AssetCategory> categories, StringBundler sb)
+		throws Exception {
+
+		PortletURL portletURL = _renderResponse.createRenderURL();
+
+		portletURL.setParameter("categoryId", StringPool.BLANK);
+
+		String originalPortletURLString = portletURL.toString();
+
+		for (AssetCategory category : categories) {
+			List<AssetCategory> categoriesChildren =
+				AssetCategoryServiceUtil.getChildCategories(
+					category.getCategoryId());
+
+			sb.append("<li class=\"tree-node\"><span>");
+
+			if (getCategoryId() == category.getCategoryId()) {
+				sb.append("<a class=\"tag-selected\" href=\"");
+				sb.append(HtmlUtil.escape(originalPortletURLString));
+			}
+			else {
+				portletURL.setParameter(
+					"categoryId", String.valueOf(category.getCategoryId()));
+
+				sb.append("<a href=\"");
+				sb.append(HtmlUtil.escape(portletURL.toString()));
+			}
+
+			sb.append("\">");
+			sb.append(
+				HtmlUtil.escape(category.getTitle(_themeDisplay.getLocale())));
+			sb.append("</a>");
+			sb.append("</span>");
+
+			if (!categoriesChildren.isEmpty()) {
+				sb.append("<ul>");
+
+				_buildCategoriesNavigation(categoriesChildren, sb);
+
+				sb.append("</ul>");
+			}
+
+			sb.append("</li>");
+		}
+	}
+
+	private Long _categoryId;
+	private final HttpServletRequest _httpServletRequest;
+	private final RenderResponse _renderResponse;
+	private final ThemeDisplay _themeDisplay;
+	private List<AssetVocabulary> _vocabularies;
+	private long[] _vocabularyIds;
+
+}

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -205,6 +205,8 @@ public class AssetCategoriesNavigationDisplayContext {
 				return childCategoriesMap;
 			}
 		).put(
+			"id", category.getCategoryId()
+		).put(
 			"name",
 			HtmlUtil.escape(category.getTitle(_themeDisplay.getLocale()))
 		).put(

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
@@ -16,7 +16,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -24,11 +24,13 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.asset.taglib.internal.display.context.AssetCategoriesNavigationDisplayContext" %><%@
 page import="com.liferay.asset.taglib.internal.util.AssetCategoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>
+
+<%@ page import="java.util.Map" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@
 page import="javax.portlet.PortletResponse" %>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
@@ -20,31 +20,18 @@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.asset.kernel.model.AssetCategory" %><%@
-page import="com.liferay.asset.kernel.model.AssetVocabulary" %><%@
-page import="com.liferay.asset.kernel.service.AssetCategoryServiceUtil" %><%@
-page import="com.liferay.asset.kernel.service.AssetVocabularyServiceUtil" %><%@
+<%@ page import="com.liferay.asset.kernel.model.AssetVocabulary" %><%@
+page import="com.liferay.asset.taglib.internal.display.context.AssetCategoriesNavigationDisplayContext" %><%@
 page import="com.liferay.asset.taglib.internal.util.AssetCategoryUtil" %><%@
-page import="com.liferay.petra.string.StringBundler" %><%@
-page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.dao.orm.QueryUtil" %><%@
-page import="com.liferay.portal.kernel.exception.PortalException" %><%@
-page import="com.liferay.portal.kernel.theme.ThemeDisplay" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
-page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>
 
-<%@ page import="java.util.ArrayList" %><%@
-page import="java.util.List" %>
-
 <%@ page import="javax.portlet.PortletRequest" %><%@
-page import="javax.portlet.PortletResponse" %><%@
-page import="javax.portlet.PortletURL" %>
+page import="javax.portlet.PortletResponse" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {Treeview} from 'frontend-js-components-web';
+import React from 'react';
+
+const AssetCategoriesNavigationTreeView = ({categories, namespace}) => {
+	return (
+		<div
+			className="categories-tree container-fluid-1280"
+			id={`${namespace}categoriesContainer`}
+		>
+			<Treeview NodeComponent={Treeview.Card} nodes={categories} />
+		</div>
+	);
+};
+
+export default AssetCategoriesNavigationTreeView;

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
@@ -35,19 +35,6 @@ boolean hidePortletWhenEmpty = GetterUtil.getBoolean((String)request.getAttribut
 
 		if (Validator.isNotNull(vocabularyNavigation)) {
 			hidePortletWhenEmpty = false;
-	%>
-
-			<liferay-ui:panel
-				collapsible="<%= false %>"
-				extended="<%= true %>"
-				markupView="lexicon"
-				persistState="<%= true %>"
-				title="<%= HtmlUtil.escape(vocabulary.getUnambiguousTitle(assetCategoriesNavigationDisplayContext.getVocabularies(), themeDisplay.getSiteGroupId(), themeDisplay.getLocale())) %>"
-			>
-				<%= vocabularyNavigation %>
-			</liferay-ui:panel>
-
-	<%
 		}
 	}
 	%>
@@ -71,32 +58,17 @@ if (assetCategoriesNavigationDisplayContext.getCategoryId() > 0) {
 }
 %>
 
-<aui:script use="aui-tree-view">
-	var treeViews = A.all(
-		'#<%= namespace %>taglibAssetCategoriesNavigationPanel .lfr-asset-category-list-container'
-	);
+<%
+Map<String, Object> data = HashMapBuilder.<String, Object>put(
+	"categories", assetCategoriesNavigationDisplayContext.getCategories()
+).put(
+	"namespace", namespace
+).build();
+%>
 
-	treeViews.each(function (item, index, collection) {
-		var assetCategoryList = item.one('.lfr-asset-category-list');
-
-		var treeView = new A.TreeView({
-			boundingBox: item,
-			contentBox: assetCategoryList,
-			type: 'normal',
-		}).render();
-
-		var selected = assetCategoryList.one('.tree-node .tag-selected');
-
-		if (selected) {
-			var selectedChild = treeView.getNodeByChild(selected);
-
-			selectedChild.expand();
-
-			selectedChild.eachParent(function (node) {
-				if (node instanceof A.TreeNode) {
-					node.expand();
-				}
-			});
-		}
-	});
-</aui:script>
+<div>
+	<react:component
+		data="<%= data %>"
+		module="asset_categories_navigation/js/AssetCategoriesNavigationTreeView"
+	/>
+</div>


### PR DESCRIPTION
Hey @julien 

This PR is a work on migration of `AUI tree-view` to React in `asset-taglib` module.
The old aui tree-view implementation had completely different logic than React TreeView requires, so I contacted Eudaldo who worked on modifying backend.
I created react:component and included it in the jsp where old tree-view was located, and I additionally cleaned up unnecessary code for old component. 

To test these changes  : 
1. Categorization / Categories
2. Create some categories for test

1. Create a widget page
2. Add the portlet categories navigation to a page