### PR TITLE
LPS-113561 Avoid Liferay.provide in portal-workflow-kaleo-designer-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -412,7 +412,7 @@ class Iframe extends React.Component {
 		this.delegateHandler = dom.delegate(
 			iframeWindow.document,
 			'click',
-			'.btn-cancel',
+			'.btn-cancel,.lfr-hide-dialog',
 			() => this.props.processClose()
 		);
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -332,109 +332,72 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 								</div>
 
 								<aui:script>
-									Liferay.provide(
-										window,
-										'<portlet:namespace />afterTabViewChange',
-										function (event) {
-											var tabContentNode = event.newVal.get('boundingBox');
+									function <portlet:namespace />afterTabViewChange(event) {
+										var tabContentNode = event.newVal.get('boundingBox');
 
-											var kaleoDesigner = <portlet:namespace />kaleoDesigner;
+										var kaleoDesigner = <portlet:namespace />kaleoDesigner;
 
-											if (tabContentNode === kaleoDesigner.viewNode && kaleoDesigner.editor) {
-												setTimeout(function () {
-													kaleoDesigner.set(
-														'definition',
-														kaleoDesigner.editor.get('value')
-													);
-												}, 0);
-											}
-										},
-										['aui-base']
-									);
+										if (tabContentNode === kaleoDesigner.viewNode && kaleoDesigner.editor) {
+											setTimeout(function () {
+												kaleoDesigner.set('definition', kaleoDesigner.editor.get('value'));
+											}, 0);
+										}
+									}
 
-									Liferay.provide(
-										window,
-										'<portlet:namespace />publishKaleoDefinitionVersion',
-										function () {
-											<portlet:namespace />updateContent();
+									function <portlet:namespace />publishKaleoDefinitionVersion() {
+										<portlet:namespace />updateContent();
 
-											<portlet:namespace />updateTitle();
+										<portlet:namespace />updateTitle();
 
-											<portlet:namespace />updateAction(
-												'<portlet:actionURL name="publishKaleoDefinitionVersion" />'
+										<portlet:namespace />updateAction(
+											'<portlet:actionURL name="publishKaleoDefinitionVersion" />'
+										);
+
+										submitForm(document.<portlet:namespace />fm);
+									}
+
+									function <portlet:namespace />saveKaleoDefinitionVersion() {
+										<portlet:namespace />updateContent();
+
+										<portlet:namespace />updateTitle();
+
+										<portlet:namespace />updateAction(
+											'<portlet:actionURL name="saveKaleoDefinitionVersion" />'
+										);
+
+										submitForm(document.<portlet:namespace />fm);
+									}
+
+									function <portlet:namespace />updateAction(action) {
+										var form = document.<portlet:namespace />fm;
+
+										form.setAttribute('action', action);
+									}
+
+									function <portlet:namespace />updateContent() {
+										var content = document.getElementById('<portlet:namespace />content');
+
+										var activeTab = <portlet:namespace />kaleoDesigner.contentTabView.getActiveTab();
+
+										if (activeTab === <portlet:namespace />kaleoDesigner.sourceNode) {
+											content.value = <portlet:namespace />kaleoDesigner.editor.get('value');
+										}
+										else {
+											content.value = <portlet:namespace />kaleoDesigner.getContent();
+										}
+									}
+
+									function <portlet:namespace />updateTitle() {
+										var titleComponent = Liferay.component('<portlet:namespace />title');
+
+										var titlePlaceholderInput = titleComponent.get('inputPlaceholder');
+
+										if (!titlePlaceholderInput.val()) {
+											titlePlaceholderInput.val(
+												'<liferay-ui:message key="untitled-workflow" />'
 											);
-
-											submitForm(document.<portlet:namespace />fm);
-										},
-										['aui-base']
-									);
-
-									Liferay.provide(
-										window,
-										'<portlet:namespace />saveKaleoDefinitionVersion',
-										function () {
-											<portlet:namespace />updateContent();
-
-											<portlet:namespace />updateTitle();
-
-											<portlet:namespace />updateAction(
-												'<portlet:actionURL name="saveKaleoDefinitionVersion" />'
-											);
-
-											submitForm(document.<portlet:namespace />fm);
-										},
-										['aui-base']
-									);
-
-									Liferay.provide(
-										window,
-										'<portlet:namespace />updateAction',
-										function (action) {
-											var A = AUI();
-
-											var form = A.one(document.<portlet:namespace />fm);
-
-											form.attr('action', action);
-										},
-										['aui-base']
-									);
-
-									Liferay.provide(
-										window,
-										'<portlet:namespace />updateContent',
-										function () {
-											var A = AUI();
-
-											var content = A.one('#<portlet:namespace />content');
-
-											var activeTab = <portlet:namespace />kaleoDesigner.contentTabView.getActiveTab();
-
-											if (activeTab === <portlet:namespace />kaleoDesigner.sourceNode) {
-												content.val(<portlet:namespace />kaleoDesigner.editor.get('value'));
-											}
-											else {
-												content.val(<portlet:namespace />kaleoDesigner.getContent());
-											}
-										},
-										['aui-base']
-									);
-
-									Liferay.provide(
-										window,
-										'<portlet:namespace />updateTitle',
-										function () {
-											var titleComponent = Liferay.component('<portlet:namespace />title');
-
-											var titlePlaceholderInput = titleComponent.get('inputPlaceholder');
-
-											if (!titlePlaceholderInput.val()) {
-												titlePlaceholderInput.val(
-													'<liferay-ui:message key="untitled-workflow" />'
-												);
-											}
-										},
-										['aui-base']
-									);
+										}
+									}
 
 									Liferay.provide(
 										window,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -332,7 +332,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 								</div>
 
 								<aui:script>
-									function <portlet:namespace />afterTabViewChange(event) {
+									window['<portlet:namespace />afterTabViewChange'] = function (event) {
 										var tabContentNode = event.newVal.get('boundingBox');
 
 										var kaleoDesigner = <portlet:namespace />kaleoDesigner;
@@ -342,9 +342,9 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 												kaleoDesigner.set('definition', kaleoDesigner.editor.get('value'));
 											}, 0);
 										}
-									}
+									};
 
-									function <portlet:namespace />publishKaleoDefinitionVersion() {
+									window['<portlet:namespace />publishKaleoDefinitionVersion'] = function () {
 										<portlet:namespace />updateContent();
 
 										<portlet:namespace />updateTitle();
@@ -354,9 +354,9 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										);
 
 										submitForm(document.<portlet:namespace />fm);
-									}
+									};
 
-									function <portlet:namespace />saveKaleoDefinitionVersion() {
+									window['<portlet:namespace />saveKaleoDefinitionVersion'] = function () {
 										<portlet:namespace />updateContent();
 
 										<portlet:namespace />updateTitle();
@@ -366,15 +366,15 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										);
 
 										submitForm(document.<portlet:namespace />fm);
-									}
+									};
 
-									function <portlet:namespace />updateAction(action) {
+									window['<portlet:namespace />updateAction'] = function (action) {
 										var form = document.<portlet:namespace />fm;
 
 										form.setAttribute('action', action);
-									}
+									};
 
-									function <portlet:namespace />updateContent() {
+									window['<portlet:namespace />updateContent'] = function () {
 										var content = document.getElementById('<portlet:namespace />content');
 
 										var activeTab = <portlet:namespace />kaleoDesigner.contentTabView.getActiveTab();
@@ -385,9 +385,9 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										else {
 											content.value = <portlet:namespace />kaleoDesigner.getContent();
 										}
-									}
+									};
 
-									function <portlet:namespace />updateTitle() {
+									window['<portlet:namespace />updateTitle'] = function () {
 										var titleComponent = Liferay.component('<portlet:namespace />title');
 
 										var titlePlaceholderInput = titleComponent.get('inputPlaceholder');
@@ -397,7 +397,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 												'<liferay-ui:message key="untitled-workflow" />'
 											);
 										}
-									}
+									};
 
 									Liferay.provide(
 										window,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -399,19 +399,6 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										}
 									};
 
-									Liferay.provide(
-										window,
-										'<portlet:namespace />closeKaleoDialog',
-										function () {
-											var dialog = Liferay.Util.getWindow();
-
-											if (dialog) {
-												dialog.destroy();
-											}
-										},
-										['aui-base']
-									);
-
 									<%
 									String saveCallback = ParamUtil.getString(request, "saveCallback");
 									%>
@@ -674,44 +661,6 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 											}
 										</c:when>
 									</c:choose>
-
-									var dialog = Liferay.Util.getWindow();
-
-									if (dialog && !dialog._dialogAction) {
-										dialog._dialogAction = function (event) {
-											if (!event.newVal) {
-
-												<%
-												boolean refreshOpenerOnClose = ParamUtil.getBoolean(request, "refreshOpenerOnClose");
-												%>
-
-												<c:if test="<%= Validator.isNotNull(portletResourceNamespace) && refreshOpenerOnClose %>">
-
-													<%
-													String openerWindowName = ParamUtil.getString(request, "openerWindowName");
-													%>
-
-													var openerWindow = Liferay.Util.getTop();
-
-													<c:if test="<%= Validator.isNotNull(openerWindowName) %>">
-														var openerDialog = Liferay.Util.getWindow(
-															'<%= HtmlUtil.escapeJS(openerWindowName) %>'
-														);
-
-														openerWindow = openerDialog.iframe.node
-															.get('contentWindow')
-															.getDOM();
-													</c:if>
-
-													openerWindow.Liferay.Portlet.refresh(
-														'#p_p_id<%= HtmlUtil.escapeJS(portletResourceNamespace) %>'
-													);
-												</c:if>
-											}
-										};
-
-										dialog.on('visibleChange', dialog._dialogAction);
-									}
 								</aui:script>
 							</aui:fieldset>
 						</aui:fieldset-group>
@@ -728,7 +677,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 									</c:if>
 
 									<c:if test="<%= Validator.isNotNull(closeRedirect) %>">
-										<aui:button onClick='<%= renderResponse.getNamespace() + "closeKaleoDialog();" %>' value="cancel" />
+										<aui:button type="cancel" />
 									</c:if>
 
 									<span class="lfr-portlet-workflowdesigner-message" id="<portlet:namespace />toolbarMessage"></span>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
@@ -257,21 +257,13 @@ if (tabs1.equals("published")) {
 		['aui-base']
 	);
 
-	Liferay.provide(
-		window,
-		'<portlet:namespace />editWorkflow',
-		function (uri) {
-			var A = AUI();
-
-			var WIN = A.config.win;
-
-			Liferay.Util.openWindow({
-				id: A.guid(),
-				refreshWindow: WIN,
-				title: '<liferay-ui:message key="workflow" />',
-				uri: uri,
-			});
-		},
-		['liferay-util']
-	);
+	window['<portlet:namespace />editWorkflow'] = function (url) {
+		Liferay.Util.openModal({
+			onClose: function () {
+				window.location.reload();
+			},
+			title: '<liferay-ui:message key="workflow" />',
+			url: url,
+		});
+	};
 </aui:script>

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -1038,36 +1038,38 @@ if (themeDisplay.isStatePopUp()) {
 		<aui:script use="aui-base">
 			var dialog = Liferay.Util.getWindow();
 
-			var hideDialogSignature = '<portlet:namespace />hideRefreshDialog|*';
+			if (dialog) {
+				var hideDialogSignature = '<portlet:namespace />hideRefreshDialog|*';
 
-			dialog.detach(hideDialogSignature);
+				dialog.detach(hideDialogSignature);
 
-			dialog.on(
-				'<portlet:namespace />hideRefreshDialog|visibleChange',
-				function(event) {
-					if (!event.newVal && event.src !== 'hideLink') {
-						var refreshWindow = dialog._refreshWindow || Liferay.Util.getTop();
+				dialog.on(
+					'<portlet:namespace />hideRefreshDialog|visibleChange',
+					function(event) {
+						if (!event.newVal && event.src !== 'hideLink') {
+							var refreshWindow = dialog._refreshWindow || Liferay.Util.getTop();
 
-						var topA = refreshWindow.AUI();
+							var topA = refreshWindow.AUI();
 
-						topA.use(
-							'aui-loading-mask-deprecated',
-							function(A) {
-								new A.LoadingMask(
-									{
-										target: A.getBody()
-									}
-								).show();
-							}
-						);
+							topA.use(
+								'aui-loading-mask-deprecated',
+								function(A) {
+									new A.LoadingMask(
+										{
+											target: A.getBody()
+										}
+									).show();
+								}
+							);
 
-						refreshWindow.location.href = '<%= HtmlUtil.escapeJS(closeRedirect) %>';
+							refreshWindow.location.href = '<%= HtmlUtil.escapeJS(closeRedirect) %>';
+						}
+						else {
+							dialog.detach(hideDialogSignature);
+						}
 					}
-					else {
-						dialog.detach(hideDialogSignature);
-					}
-				}
-			);
+				);
+			}
 		</aui:script>
 
 	<%


### PR DESCRIPTION
Hey @julien ,

This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/31. I tried to sneak in commit on that branch, but I don't have permissions.

I updated modal to use `openModal`:
- A lot of code is replaced by `<aui:button type='cancel'>` that closes modal out of the box.
- We are refreshing page after modal close with `window.location.reload();`
- The code in `render_portlet.jsp` will be executed only if modal is AUI. This is a bit of a quick workaround, cleaner but riskier solution would be to clean up backend not to set `SessionMessages.KEY_SUFFIX_CLOSE_REDIRECT`.
- We needed to add support in new modal for close on `.lfr-hide-dialog` link, this is the 'hide this dialog'  link in publish success message.

Please check if everything works as it should.

If there are issues with this solution, there is a quicker but uglier one, to use `closeWindow` event:
```js
window['<portlet:namespace />closeKaleoDialog'] = function () {
	Liferay.fire('closeWindow', {
		id: 'editWorkflowWindow'
	});
}
```
and in modal init
```js
Liferay.Util.openWindow({
	id: 'editWorkflowWindow',
	...
});
}
```
There are two problems with this:
1. We are hiding the window instead of destroying it. This might be fine, I don't know if there is a reason why we are explicitly destroying it.
2. Modal is still AUI modal. We will eventually need to replace `provide` in `portal-workflow-kaleo-forms-web`, and that means updating `openWindow` to `openModal`. But, we can do it in a separate task.

Thank you!

/cc @jbalsas